### PR TITLE
chore: enhance validation for asset type fields

### DIFF
--- a/inventory-api/tests/assetTypeFields.test.js
+++ b/inventory-api/tests/assetTypeFields.test.js
@@ -74,6 +74,27 @@ describe('Asset Type Fields API', () => {
 
       expect(res.statusCode).toEqual(400);
     });
+
+    it('should return 400 if options contain duplicates', async () => {
+      const selectType = await prisma.field_types.create({
+        data: {
+          name: 'Select With Options',
+          slug: `select-${Date.now()}`,
+          has_options: true,
+        },
+      });
+
+      const res = await request(app)
+        .post(`/assets/asset-types/${testAssetType.id}/fields`)
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: 'Bad Options Field',
+          field_type_id: selectType.id,
+          options: ['A', 'A'],
+        });
+
+      expect(res.statusCode).toEqual(400);
+    });
   });
 
   describe('GET /:assetTypeId/fields', () => {

--- a/inventory-api/tests/fieldTypes.test.js
+++ b/inventory-api/tests/fieldTypes.test.js
@@ -1,0 +1,41 @@
+const request = require('supertest');
+const { PrismaClient } = require('../generated/prisma');
+const { app } = require('../server');
+
+const prisma = new PrismaClient();
+
+beforeAll(async () => {
+  await prisma.$connect();
+  await prisma.field_types.deleteMany({});
+});
+
+afterAll(async () => {
+  try {
+    await prisma.field_types.deleteMany({});
+  } finally {
+    await prisma.$disconnect();
+  }
+});
+
+describe('Field Types API', () => {
+  it('creates field types with unique slugs', async () => {
+    const res1 = await request(app)
+      .post('/field-types')
+      .send({ name: 'Quantity' });
+    expect(res1.statusCode).toBe(201);
+    expect(res1.body.slug).toBe('quantity');
+
+    const res2 = await request(app)
+      .post('/field-types')
+      .send({ name: 'Quantity' });
+    expect(res2.statusCode).toBe(201);
+    expect(res2.body.slug).toBe('quantity-1');
+  });
+
+  it('rejects invalid payloads', async () => {
+    const res = await request(app)
+      .post('/field-types')
+      .send({ name: '', has_options: 'yes' });
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- expand server-side validation for asset type field creation and updates
- enforce validation on updates and require unique option values
- add test to ensure duplicate options are rejected
- strengthen field type creation with strict payload checks and automatic unique slug generation
- add tests covering field type validation

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:ci` *(fails: Database connection error - missing `DATABASE_URL` env var)*

------
https://chatgpt.com/codex/tasks/task_e_68be88839734832daa7fd9932962ee13